### PR TITLE
Add repo link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": "",
   "license": "MIT",
-  "author": "",
+  "author": "https://github.com/pzuraq/ember-set-helper",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
This makes it much easier to navigate to the GH repo from the npm package.