### PR TITLE
Fix AST transform for case of setting argument property

### DIFF
--- a/lib/set-placeholder-transform.js
+++ b/lib/set-placeholder-transform.js
@@ -51,14 +51,18 @@ module.exports = class SetPlaceholderTransform {
         if (node.params.length === 2) {
           let path = node.params.shift();
 
+          let key = path.parts.pop();
+
           let splitPoint = path.original.lastIndexOf('.');
+          if (splitPoint === -1) {
+            // Implicit this
+            path.original = 'this';
+            path.parts = ['this'];
+          } else {
+            path.original = path.original.substr(0, splitPoint);
+          }
 
-          let key = path.original.substr(splitPoint + 1);
-
-          let target =
-            splitPoint === -1 ? 'this' : path.original.substr(0, splitPoint);
-
-          node.params.unshift(b.path(target), b.string(key));
+          node.params.unshift(path, b.string(key));
         }
       }
     }

--- a/tests/integration/helpers/set-test.js
+++ b/tests/integration/helpers/set-test.js
@@ -70,4 +70,21 @@ module('Integration | Helper | set', function(hooks) {
 
     assert.equal(find('[data-test-greeting]').textContent.trim(), 'Hola!');
   });
+
+  test('set helper works with argument', async function(assert) {
+    this.set('greeting', { hi: 'Hi!' });
+
+    this.owner.register('template:components/greeting', hbs`
+      <button
+        value="Hola!"
+        {{on "click" (set @greeting.hi (get _ "target.value"))}}
+      >
+        Español
+      </button>
+    `);
+    await render(hbs`<Greeting @greeting={{this.greeting}}/>`);
+
+    await click('button');
+    assert.equal(this.greeting.hi, 'Hola!');
+  });
 });


### PR DESCRIPTION
Setting argument property works for Ember 3.16 but fails on 3.17.
{{set @greeting.hi "Hola"}}
This pr fixes the transform to make it work with Ember 3.17.