### PR TITLE
Remove target from assertion to better align with `mut`

### DIFF
--- a/addon/helpers/set.js
+++ b/addon/helpers/set.js
@@ -1,5 +1,4 @@
 import { helper } from '@ember/component/helper';
-import { assert } from '@ember/debug';
 import { set as emberSet } from '@ember/object';
 
 function set(positional, named) {
@@ -15,14 +14,11 @@ function set(positional, named) {
     path = maybePath;
   }
 
-  assert(
-    'you must pass a path to {{set}}. You can pass a path statically, as in `{{set this.foo}}`, or with the path argument dynamically, as in `{{set this path="foo"}}`',
-    Boolean(target) && (typeof path === 'string' && path.length > 0 || typeof path === 'symbol' || typeof path === 'number')
-  );
-
-  return positional.length === 3
-    ? () => emberSet(target, path, maybeValue)
-    : value => emberSet(target, path, value);
+  if (path) {
+    return positional.length === 3
+      ? () => emberSet(target, path, maybeValue)
+      : value => emberSet(target, path, value);
+  }
 }
 
 export default helper(set);

--- a/addon/helpers/set.js
+++ b/addon/helpers/set.js
@@ -17,7 +17,7 @@ function set(positional, named) {
 
   assert(
     'you must pass a path to {{set}}. You can pass a path statically, as in `{{set this.foo}}`, or with the path argument dynamically, as in `{{set this path="foo"}}`',
-    typeof path === 'string' && path.length > 0 || typeof path === 'symbol' || typeof path === 'number')
+    (typeof path === 'string' && path.length > 0 || typeof path === 'symbol' || typeof path === 'number')
   );
 
   return positional.length === 3

--- a/addon/helpers/set.js
+++ b/addon/helpers/set.js
@@ -1,4 +1,5 @@
 import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
 import { set as emberSet } from '@ember/object';
 
 function set(positional, named) {
@@ -14,11 +15,14 @@ function set(positional, named) {
     path = maybePath;
   }
 
-  if (path) {
-    return positional.length === 3
-      ? () => emberSet(target, path, maybeValue)
-      : value => emberSet(target, path, value);
-  }
+  assert(
+    'you must pass a path to {{set}}. You can pass a path statically, as in `{{set this.foo}}`, or with the path argument dynamically, as in `{{set this path="foo"}}`',
+    typeof path === 'string' && path.length > 0 || typeof path === 'symbol' || typeof path === 'number')
+  );
+
+  return positional.length === 3
+    ? () => emberSet(target, path, maybeValue)
+    : value => emberSet(target, path, value);
 }
 
 export default helper(set);


### PR DESCRIPTION
`mut` was able to handle `undefined` values. This was very helpful for things like testing, where you may only want to define a few values, not everything for your whole app.