### PR TITLE
feat: add index re-export

### DIFF
--- a/ember-set-helper/src/index.ts
+++ b/ember-set-helper/src/index.ts
@@ -1,0 +1,1 @@
+export { default as set } from './helpers/set.ts';


### PR DESCRIPTION
just for convenience so consumers can do:

`import { set } from 'ember-set-helper'`